### PR TITLE
Fix arrow in Safari when having a base element

### DIFF
--- a/src/SvgArrow.js
+++ b/src/SvgArrow.js
@@ -109,7 +109,7 @@ const SvgArrow = ({
     <path
       d={pathString}
       style={{ fill: 'none', stroke: strokeColor, strokeWidth }}
-      markerEnd="url(#arrow)"
+      markerEnd={`url(${location.href}#arrow)`}
     />
   );
 };

--- a/src/SvgArrow.test.js
+++ b/src/SvgArrow.test.js
@@ -189,7 +189,7 @@ describe('SvgArrow', () => {
 
       expect(path.props()).toMatchObject({
         d: 'M10,10 C10,10 30,10 30,10',
-        markerEnd: 'url(#arrow)',
+        markerEnd: 'url(about:blank#arrow)',
         style: {
           strokeWidth: 2,
           stroke: 'blue',


### PR DESCRIPTION
The arrow isn’t visible in Safari when having a `base` element:

```html
<base href="/">
```

One basically need the base element when using a client side Router in html5 mode (History API)

Reference: [Stack Overflow](https://stackoverflow.com/questions/18259032/using-base-tag-on-a-page-that-contains-svg-marker-elements-fails-to-render-marke/18265336#18265336)

## Before:

![image](https://user-images.githubusercontent.com/441011/39944345-a4296b26-5566-11e8-8793-8ea392fb6836.png)


## After:

![image](https://user-images.githubusercontent.com/441011/39944327-8c4bdd7c-5566-11e8-8c2d-b78311abaa19.png)
