### PR TITLE
Prevent null child register

### DIFF
--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -117,18 +117,16 @@ export class ArcherContainer extends React.Component {
     });
   };
 
-  registerChild = id => {
-    return ref => {
-      if (!this.state.refs[id]) {
-        this.state.observer.observe(ref);
-        this.setState(currentState => {
-          return {
-            ...this.currentState,
-            refs: { ...currentState.refs, [id]: ref },
-          };
-        });
-      }
-    };
+  registerChild = (id, ref) => {
+    if (!this.state.refs[id]) {
+      this.state.observer.observe(ref);
+      this.setState(currentState => {
+        return {
+          ...this.currentState,
+          refs: { ...currentState.refs, [id]: ref },
+        };
+      });
+    }
   };
 
   computeArrows = () => {

--- a/src/ArcherElement.js
+++ b/src/ArcherElement.js
@@ -36,12 +36,19 @@ export class ArcherElement extends React.Component {
     });
   }
 
+  onRefUpdate = ref => {
+    if (!ref) {
+      return;
+    }
+    this.context.registerChild(this.props.id, ref);
+  };
+
   render() {
     return (
       <div
         style={{ ...this.props.style, position: 'relative' }}
         className={this.props.className}
-        ref={this.context.registerChild(this.props.id)}
+        ref={this.onRefUpdate}
       >
         {this.props.children}
       </div>

--- a/src/ArcherElement.test.js
+++ b/src/ArcherElement.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import ArcherElement from './ArcherElement';
 
 let wrapper;
@@ -22,9 +22,14 @@ describe('ArcherElement', () => {
     expect(wrapper.props().children).toEqual(children);
   });
 
-  it('should call registerChild in ref callback', () => {
-    wrapper.setProps({ id: 'the id' });
-    expect(registerChildMock).toHaveBeenCalledWith('the id');
+  it('should register child on mounting ref callback', () => {
+    const context = { registerChild: registerChildMock };
+    const props = { ...defaultProps, id: 'the id' };
+    wrapper = mount(<ArcherElement {...props} />, { context });
+
+    expect(registerChildMock).toHaveBeenCalledWith('the id', expect.anything());
+    wrapper.unmount();
+    expect(registerChildMock).toHaveBeenCalledTimes(1);
   });
 
   describe('lifecycle', () => {


### PR DESCRIPTION
# What was the problem
In the current implementation it's possible that [registerChild](https://github.com/pierpo/react-archer/blob/master/src/ArcherContainer.js#L121) is invoked with a `ref` value of `null` since [the callback is triggered not just on mount but unmount as well](https://reactjs.org/docs/refs-and-the-dom.html#callback-refs). Since a ResizeObserver needs a valid DOM node to subscribe an error is thrown in that case.

# How was it resolved
Adding a check if a reference is available prevents registering children for `null`. By extracting the logic in it's own function the `registerChild` parameters could also be simplified. Previously the test didn't cover the actual case as the ref callback is not triggered through `shallow` rendering. Using `mount` ensures it's executed correctly. Hopefully this helps 😄 