### PR TITLE
Fix duplicate SVGs when add more relation to element

### DIFF
--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -154,7 +154,6 @@ export class ArcherContainer extends React.Component<Props, State> {
   };
 
   registerTransition = (fromElement: string, relation: RelationType): void => {
-    // TODO prevent duplicate registering
     // TODO improve the state merge... (should be shorter)
     const fromTo = [...this.state.fromTo];
     const newFromTo = {
@@ -168,7 +167,7 @@ export class ArcherContainer extends React.Component<Props, State> {
       // I wrote an issue on Flow, let's see what happens.
       // https://github.com/facebook/flow/issues/7135
       // $FlowFixMe
-      fromTo: [...currentState.fromTo, ...fromTo],
+      fromTo: [...fromTo],
     }));
   };
 


### PR DESCRIPTION
Fix SVGs being duplicated when try to add more relations to ArcherElement (I think this is same problem as #7)

I think this is because `fromTo` in current state will be duplicated when `registerTransition` is called.

It seems to work fine to me now and 'two children with the same key' error is gone too.

Thanks for the component :)