### PR TITLE
Prevent fromTo duplicates in registerTransition

### DIFF
--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -154,23 +154,23 @@ export class ArcherContainer extends React.Component<Props, State> {
   };
 
   registerTransition = (fromElement: string, relation: RelationType): void => {
-    // TODO improve the state merge... (should be shorter)
     const { fromTo } = this.state;
-    const newFromTo = [
-      ...(!fromTo.find(sd => sd.from.id === fromElement) ? [{
-        ...relation,
-        from: { ...relation.from, id: fromElement },
-      }]: []),
-      ...fromTo,
-    ];
-
-    this.setState(() => ({
-      // Really can't find a solution for this Flow error. I think it's a bug.
-      // I wrote an issue on Flow, let's see what happens.
+    const relationExists = fromTo.find(sd => sd.from.id === fromElement && sd.to.id === relation.to.id);
+    if (!relationExists) {
+      // Destructure and use all the properties to work around issue with spreading different Flow types
       // https://github.com/facebook/flow/issues/7135
       // $FlowFixMe
-      fromTo: newFromTo,
-    }));
+      const { to, label, style } = relation;
+      const from = {
+        anchor: relation.from.anchor,
+        id: fromElement,
+      };
+      const newFromTo = [
+        ...fromTo,
+        { to, label, style, from },
+      ];
+      this.setState(() => ({ fromTo: newFromTo }));
+    }
   };
 
   registerChild = (id: string, ref: HTMLElement): void => {

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -154,21 +154,22 @@ export class ArcherContainer extends React.Component<Props, State> {
   };
 
   registerTransition = (fromElement: string, relation: RelationType): void => {
-    // TODO prevent duplicate registering
     // TODO improve the state merge... (should be shorter)
-    const fromTo = [...this.state.fromTo];
-    const newFromTo = {
-      ...relation,
-      from: { ...relation.from, id: fromElement },
-    };
-    fromTo.push(newFromTo);
+    const { fromTo } = this.state;
+    const newFromTo = [
+      ...(!fromTo.find(sd => sd.from.id === fromElement) ? [{
+        ...relation,
+        from: { ...relation.from, id: fromElement },
+      }]: []),
+      ...fromTo,
+    ];
 
-    this.setState((currentState: State) => ({
+    this.setState(() => ({
       // Really can't find a solution for this Flow error. I think it's a bug.
       // I wrote an issue on Flow, let's see what happens.
       // https://github.com/facebook/flow/issues/7135
       // $FlowFixMe
-      fromTo: [...currentState.fromTo, ...fromTo],
+      fromTo: newFromTo,
     }));
   };
 

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -155,7 +155,7 @@ export class ArcherContainer extends React.Component<Props, State> {
 
   registerTransition = (fromElement: string, relation: RelationType): void => {
     const { fromTo } = this.state;
-    const relationExists = fromTo.find(sd => sd.from.id === fromElement && sd.to.id === relation.to.id);
+    const relationExists = Boolean(fromTo.find(sd => sd.from.id === fromElement && sd.to.id === relation.to.id));
     if (!relationExists) {
       // Destructure and use all the properties to work around issue with spreading different Flow types
       // https://github.com/facebook/flow/issues/7135


### PR DESCRIPTION
There was a `TODO  prevent duplicate registering` and I had a bug because a component was mounting more than once and calling this `registerTransition()` method.

I suppose the `componentWillUnmount` of the `ArcherElement` should also de-register, and probably there still needs to be an error thrown if a component tries to register but it's already there.

To simplify merging the state, I tried to use `this.setState({ fromTo: newFromTo })` directly but it's causing some problem with the Flow type:

``` 
Cannot call this.setState with object literal bound to partialState because property id is missing in
IncompleteRelationNozzleType [1] but exists in RelationNozzleType [2] in property from of array element.
 ```

So I kept this original with the callback function but simplified it by using `newFromTo` as the new array (also more clear naming I think).