### PR TITLE
Unregister transitions (fromTo) and ref when unmounting elements (#17)

### DIFF
--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -58,6 +58,8 @@ function computeCoordinatesFromAnchorPosition(
 export type ArcherContainerContextType = {
   registerChild?: (string, HTMLElement) => void,
   registerTransition?: (string, RelationType) => void,
+  unregisterChild?: (string) => void,
+  unregisterAllTransitions?: (string) => void,
 };
 
 const ArcherContainerContext = React.createContext<ArcherContainerContextType>(
@@ -172,6 +174,12 @@ export class ArcherContainer extends React.Component<Props, State> {
     }));
   };
 
+  unregisterAllTransitions = (element: string): void => {
+    const { fromTo } = this.state;
+    const newFromTo = fromTo.filter(sd => sd.from.id !== element && sd.to.id !== element);
+    this.setState(() => ({ fromTo: newFromTo }));
+  };
+
   registerChild = (id: string, ref: HTMLElement): void => {
     if (!this.state.refs[id]) {
       this.state.observer.observe(ref);
@@ -179,6 +187,14 @@ export class ArcherContainer extends React.Component<Props, State> {
         refs: { ...currentState.refs, [id]: ref },
       }));
     }
+  };
+
+  unregisterChild = (id: string): void => {
+    const { refs, observer } = this.state;
+    observer.unobserve(refs[id]);
+    const newRefs = { ...refs };
+    newRefs[id] = null;
+    this.setState(() => ({ refs: newRefs, }));
   };
 
   computeArrows = (): React$Node => {
@@ -276,7 +292,9 @@ export class ArcherContainer extends React.Component<Props, State> {
       <ArcherContainerContextProvider
         value={{
           registerTransition: this.registerTransition,
+          unregisterAllTransitions: this.unregisterAllTransitions,
           registerChild: this.registerChild,
+          unregisterChild: this.unregisterChild,
         }}
       >
         <div

--- a/src/ArcherElement.js
+++ b/src/ArcherElement.js
@@ -46,6 +46,11 @@ export class ArcherElementNoContext extends React.Component<Props> {
     this.registerAllTransitions(this.props.relations);
   }
 
+  componentWillUnmount() {
+    this.unregisterChild();
+    this.unregisterAllTransitions();
+  }
+
   registerAllTransitions(relations: Array<RelationType>) {
     relations.forEach(relation => {
       if (!this.props.context.registerTransition) return;
@@ -54,12 +59,23 @@ export class ArcherElementNoContext extends React.Component<Props> {
     });
   }
 
+  unregisterAllTransitions() {
+    if (!this.props.context.unregisterAllTransitions) return;
+    this.props.context.unregisterAllTransitions(this.props.id);
+  }
+
   onRefUpdate = (ref: ?HTMLElement) => {
     if (!ref) return;
     if (!this.props.context.registerChild) return;
 
     this.props.context.registerChild(this.props.id, ref);
   };
+
+  unregisterChild() {
+    if (!this.props.context.unregisterChild) return;
+
+    this.props.context.unregisterChild(this.props.id);
+  }
 
   render() {
     return (


### PR DESCRIPTION
Adds `unregisterChild` and `unregisterAllTransition` methods called from `ArcherElement` `componentWillUnmount`