### PR TITLE
Fix - UMD bundle node

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -48,6 +48,7 @@ var config = {
     extensions: ['.js', '.jsx'],
   },
   externals: externals,
+  globalObject: 'typeof self !== \'undefined\' ? self : this',
 };
 
 if (isProd) {

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -34,6 +34,7 @@ var config = {
     sourceMapFilename: 'react-archer.sourcemap.js',
     library: 'ReactArcher',
     libraryTarget: 'umd',
+    globalObject: 'typeof self !== \'undefined\' ? self : this',
   },
   module: {
     rules: [
@@ -48,7 +49,6 @@ var config = {
     extensions: ['.js', '.jsx'],
   },
   externals: externals,
-  globalObject: 'typeof self !== \'undefined\' ? self : this',
 };
 
 if (isProd) {


### PR DESCRIPTION
@pierpo As I mentioned in the issue earlier today (although not too clearly), the bundle breaks in a node environment. Adding the `globalObject` hack as described in [this issue](https://github.com/webpack/webpack/issues/6522) fixes the bug