### PR TITLE
SSR: Checking window object before adding listeners

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,7 +25,8 @@
     "expect": true,
     "it": true,
     "describe": true,
-    "beforeEach": true
+    "beforeEach": true,
+    "window": true
   },
   "rules": {}
 }

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -110,7 +110,7 @@ export class ArcherContainer extends React.Component<Props, State> {
   };
 
   componentDidMount() {
-    window.addEventListener('resize', this.refreshScreen);
+    if (window) window.addEventListener('resize', this.refreshScreen);
   }
 
   componentWillUnmount() {
@@ -120,7 +120,7 @@ export class ArcherContainer extends React.Component<Props, State> {
       observer.unobserve(this.state.refs[elementKey]);
     });
 
-    window.removeEventListener('resize', this.refreshScreen);
+    if (window) window.removeEventListener('resize', this.refreshScreen);
   }
 
   refreshScreen = (): void => {

--- a/src/ArcherContainer.test.js
+++ b/src/ArcherContainer.test.js
@@ -141,4 +141,30 @@ describe('ArcherContainer', () => {
       });
     });
   });
+
+  describe('Event Listeners', () => {
+    it('should add resize listeners when mounting', () => {
+      global.window.addEventListener = jest.fn();
+      shallow(<ArcherContainer {...defaultProps} />);
+
+      expect(global.window.addEventListener).toBeCalledWith(
+        'resize',
+        expect.anything(),
+      );
+    });
+
+    it('should remove resize listeners when mounting', () => {
+      global.window.removeEventListener = jest.fn();
+      const wrapper: ShallowWrapper = shallow(
+        <ArcherContainer {...defaultProps} />,
+      );
+
+      wrapper.unmount();
+
+      expect(global.window.removeEventListener).toBeCalledWith(
+        'resize',
+        expect.anything(),
+      );
+    });
+  });
 });

--- a/src/ArcherContainer.test.js
+++ b/src/ArcherContainer.test.js
@@ -35,7 +35,7 @@ describe('ArcherContainer', () => {
           },
         },
       ],
-    }
+    },
   };
 
   const shallowRenderAndSetState = (newState?: WrapperState) => {
@@ -143,20 +143,15 @@ describe('ArcherContainer', () => {
   });
 
   describe('Event Listeners', () => {
-    it('should add resize listeners when mounting', () => {
+    it('should add/remove resize listeners when mounting/unmounting', () => {
       global.window.addEventListener = jest.fn();
-      shallow(<ArcherContainer {...defaultProps} />);
+      global.window.removeEventListener = jest.fn();
+
+      const wrapper: ShallowWrapper = shallowRenderAndSetState();
 
       expect(global.window.addEventListener).toBeCalledWith(
         'resize',
         expect.anything(),
-      );
-    });
-
-    it('should remove resize listeners when mounting', () => {
-      global.window.removeEventListener = jest.fn();
-      const wrapper: ShallowWrapper = shallow(
-        <ArcherContainer {...defaultProps} />,
       );
 
       wrapper.unmount();


### PR DESCRIPTION
This change allows react-archer to be rendered from the server side.