### PR TITLE
Use current state for unregisterChild/unregisterTransitions

### DIFF
--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -195,7 +195,7 @@ export class ArcherContainer extends React.Component<Props, State> {
 
   unregisterChild = (id: string): void => {
     this.setState((currentState: State) => {
-      currentState.observer.unobserve(refs[id]);
+      currentState.observer.unobserve(currentState.refs[id]);
       const newRefs = { ...(currentState.refs) };
       delete newRefs[id];
       return { refs: newRefs }

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -176,13 +176,11 @@ export class ArcherContainer extends React.Component<Props, State> {
   };
 
   unregisterTransitions = (elementId: string): void => {
-    const { sourceToTargetsMap } = this.state;
-
-    const sourceToTargetsMapCopy = { ...sourceToTargetsMap };
-
-    delete sourceToTargetsMapCopy[elementId];
-
-    this.setState(() => ({ sourceToTargetsMap: sourceToTargetsMapCopy }));
+    this.setState((currentState) => {
+      const sourceToTargetsMapCopy = { ...(currentState.sourceToTargetsMap) };
+      delete sourceToTargetsMapCopy[elementId];
+      return { sourceToTargetsMap: sourceToTargetsMapCopy }
+    });
   };
 
   registerChild = (id: string, ref: HTMLElement): void => {
@@ -196,11 +194,12 @@ export class ArcherContainer extends React.Component<Props, State> {
   };
 
   unregisterChild = (id: string): void => {
-    const { refs, observer } = this.state;
-    observer.unobserve(refs[id]);
-    const newRefs = { ...refs };
-    delete newRefs[id];
-    this.setState(() => ({ refs: newRefs }));
+    this.setState((currentState: State) => {
+      currentState.observer.unobserve(refs[id]);
+      const newRefs = { ...(currentState.refs) };
+      delete newRefs[id];
+      return { refs: newRefs }
+    });
   };
 
   getSourceToTargets = (): Array<SourceToTargetType> => {


### PR DESCRIPTION
Hi

We started using react-archer for flow analytics in our application and came across this bug.

When unregistering multiple nodes at a time, only 1 state update is actually persisted resulting in buggy ui. 

This can be reproduced by creating 2 or more nodes linked to 1 source. Then, when you unmount those nodes and remount them again, the lines of only 1 of those nodes will correctly display.
