### PR TITLE
Add optional parameter offset for padding between stroke and an element

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ export default App;
 | `strokeWidth` | `number` | A size in `px`
 | `strokeDasharray` | `string` | Adds dashes to the stroke. It has to be a string representing an array of sizes. See some [SVG strokes documentation](https://www.w3schools.com/graphics/svg_stroking.asp).
 | `noCurves` | `boolean` | Set this to true if you want angles instead of curves
+| `offset` | `number` | Optional number for space between element and start/end of stroke
 | `arrowLength` | `number` | A size in `px`
 | `arrowThickness` | `number` | A size in `px`
 | `children` | `React.Node` |

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -17,6 +17,7 @@ type Props = {
   style?: Object,
   svgContainerStyle?: Object,
   className?: string,
+  offset?: number,
 };
 
 type SourceToTargetsArrayType = Array<SourceToTargetType>;
@@ -230,6 +231,8 @@ export class ArcherContainer extends React.Component<Props, State> {
 
       const noCurves = (style && style.noCurves) || this.props.noCurves;
 
+      const offset = this.props.offset || 0;
+
       const startingAnchorOrientation = source.anchor;
       const startingPoint = this.getPointCoordinatesFromAnchorPosition(
         source.anchor,
@@ -259,6 +262,7 @@ export class ArcherContainer extends React.Component<Props, State> {
           arrowThickness={arrowThickness}
           arrowMarkerId={this.getMarkerId(source, target)}
           noCurves={!!noCurves}
+          offset={offset}
         />
       );
     });

--- a/src/SvgArrow.js
+++ b/src/SvgArrow.js
@@ -15,7 +15,7 @@ type Props = {
   arrowLabel?: ?React$Node,
   arrowMarkerId: string,
   noCurves: boolean,
-  offset: number,
+  offset?: number,
 };
 
 function computeEndingArrowDirectionVector(endingAnchorOrientation) {
@@ -137,11 +137,11 @@ function computePathString({
   xEnd: number,
   yEnd: number,
   noCurves: boolean,
-  offset: number,
+  offset?: number,
 |}): string {
   const curveMarker = noCurves ? '' : 'C';
 
-  if (offset > 0) {
+  if (offset && offset > 0) {
     const angle = Math.atan2(yAnchor1 - yStart, xAnchor1 - xStart);
 
     const xOffset = offset * Math.cos(angle);

--- a/src/SvgArrow.js
+++ b/src/SvgArrow.js
@@ -15,6 +15,7 @@ type Props = {
   arrowLabel?: ?React$Node,
   arrowMarkerId: string,
   noCurves: boolean,
+  offset: number,
 };
 
 function computeEndingArrowDirectionVector(endingAnchorOrientation) {
@@ -125,6 +126,7 @@ function computePathString({
   xEnd,
   yEnd,
   noCurves,
+  offset,
 }: {|
   xStart: number,
   yStart: number,
@@ -135,8 +137,22 @@ function computePathString({
   xEnd: number,
   yEnd: number,
   noCurves: boolean,
+  offset: number,
 |}): string {
   const curveMarker = noCurves ? '' : 'C';
+
+  if (offset > 0) {
+    const angle = Math.atan2(yAnchor1 - yStart, xAnchor1 - xStart);
+
+    const xOffset = offset * Math.cos(angle);
+    const yOffset = offset * Math.sin(angle);
+
+    xStart = xStart + xOffset;
+    xEnd = xEnd - xOffset;
+
+    yStart = yStart + yOffset;
+    yEnd = yEnd - yOffset;
+  }
 
   return (
     `M${xStart},${yStart} ` +
@@ -157,6 +173,7 @@ const SvgArrow = ({
   arrowLabel,
   arrowMarkerId,
   noCurves,
+  offset,
 }: Props) => {
   const actualArrowLength = arrowLength * 2;
 
@@ -200,6 +217,7 @@ const SvgArrow = ({
     xEnd,
     yEnd,
     noCurves,
+    offset,
   });
 
   const { xLabel, yLabel, labelWidth, labelHeight } = computeLabelDimensions(


### PR DESCRIPTION
Option to add offset from elements to stroke.
Tested on private project and on repo's example.

Example without offset:
![ProFlow](https://user-images.githubusercontent.com/19948979/66760183-e162ba80-eea1-11e9-8690-3f64d4959601.png)

Example with offset={6}:
![ProFlow](https://user-images.githubusercontent.com/19948979/66760040-9c3e8880-eea1-11e9-9439-84d935d518b4.png)
