### PR TITLE
Handle case where location has hash

### DIFF
--- a/src/SvgArrow.js
+++ b/src/SvgArrow.js
@@ -214,7 +214,7 @@ const SvgArrow = ({
       <path
         d={pathString}
         style={{ fill: 'none', stroke: strokeColor, strokeWidth, strokeDasharray }}
-        markerEnd={`url(${location.href}#${arrowMarkerId})`}
+        markerEnd={`url(${location.href.split('#')[0]}#${arrowMarkerId})`}
       />
       {arrowLabel && (
         <foreignObject


### PR DESCRIPTION
In cases where there is already a hash in the url, the arrow tips do not show up. This fixes it to ignore the existing hash.

@pierpo 