### PR TITLE
Shift svg to draw on top

### DIFF
--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -42,6 +42,7 @@ const defaultSvgContainerStyle = {
   height: '100%',
   top: 0,
   left: 0,
+  pointerEvents: 'none'
 };
 
 function rectToPoint(rect: ClientRect) {
@@ -327,14 +328,14 @@ export class ArcherContainer extends React.Component<Props, State> {
         }}
       >
         <div style={{ ...this.props.style, position: 'relative' }} className={this.props.className}>
+          <div style={{ height: '100%' }} ref={this.storeParent}>
+            {this.props.children}
+          </div>
+      
           <svg style={this.svgContainerStyle()}>
             <defs>{this.generateAllArrowMarkers()}</defs>
             {SvgArrows}
           </svg>
-
-          <div style={{ height: '100%' }} ref={this.storeParent}>
-            {this.props.children}
-          </div>
         </div>
       </ArcherContainerContextProvider>
     );

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -42,7 +42,7 @@ const defaultSvgContainerStyle = {
   height: '100%',
   top: 0,
   left: 0,
-  pointerEvents: 'none'
+  pointerEvents: 'none',
 };
 
 function rectToPoint(rect: ClientRect) {
@@ -331,7 +331,7 @@ export class ArcherContainer extends React.Component<Props, State> {
           <div style={{ height: '100%' }} ref={this.storeParent}>
             {this.props.children}
           </div>
-      
+
           <svg style={this.svgContainerStyle()}>
             <defs>{this.generateAllArrowMarkers()}</defs>
             {SvgArrows}


### PR DESCRIPTION
Moving the svg to be after the contents means that the svg will always be drawn on top. However it also requires a style of "pointer-events: 'none'" or else it will get in the way of interact-ability

This is in reference to issue 53
https://github.com/pierpo/react-archer/issues/53