### PR TITLE
Add support for markers in start

### DIFF
--- a/flow-typed/archer-types.js
+++ b/flow-typed/archer-types.js
@@ -39,6 +39,7 @@ declare type LineType = {
   strokeWidth?: number,
   strokeDasharray?: string,
   noCurves?: boolean,
+  startMarker?: boolean,
 };
 
 type ValidShapeTypes = 'arrow' | 'circle';

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -16,6 +16,7 @@ export type ArcherContainerContextType = {
 type FunctionChild = (context: React$Context<ArcherContainerContextType>) => React$Node;
 
 type Props = {
+  startMarker?: boolean,
   endShape?: ShapeType,
   strokeColor: string,
   strokeWidth: number,
@@ -276,6 +277,8 @@ export class ArcherContainer extends React.Component<Props, State> {
 
     return this._getSourceToTargets().map(
       ({ source, target, label, style = {} }: SourceToTargetType) => {
+        const startMarker = style.startMarker || this.props.startMarker;
+
         const endShape = this._createShapeObj(style);
 
         const strokeColor = style.strokeColor || this.props.strokeColor;
@@ -316,6 +319,7 @@ export class ArcherContainer extends React.Component<Props, State> {
             arrowMarkerId={this._getMarkerId(source, target)}
             noCurves={!!noCurves}
             offset={offset}
+            enableStartMarker={!!startMarker}
             endShape={endShape}
           />
         );
@@ -417,7 +421,7 @@ export class ArcherContainer extends React.Component<Props, State> {
           markerHeight={markerHeight}
           refX={refX}
           refY={refY}
-          orient="auto"
+          orient="auto-start-reverse"
           markerUnits="strokeWidth"
         >
           {path}

--- a/src/ArcherContainer.test.js
+++ b/src/ArcherContainer.test.js
@@ -67,6 +67,34 @@ describe('ArcherContainer', () => {
     },
   };
 
+  const MarkerAtBothEndsState: WrapperState = {
+    sourceToTargetsMap: {
+      bar: [
+        {
+          source: {
+            anchor: 'top',
+            id: 'first-element',
+          },
+          target: {
+            anchor: 'bottom',
+            id: 'second-element',
+          },
+          style: {
+            startMarker: true,
+            endShape: {
+              circle: {
+                radius: 11,
+                strokeWidth: 2,
+                strokeColor: 'tomato',
+                fillColor: '#c0ffee',
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
   const shallowRenderAndSetState = (newState?: WrapperState) => {
     const wrapper = shallow(
       <ArcherContainer {...defaultProps}>
@@ -109,7 +137,7 @@ describe('ArcherContainer', () => {
         markerHeight: 30,
         refX: 0,
         refY: 15,
-        orient: 'auto',
+        orient: 'auto-start-reverse',
         markerUnits: 'strokeWidth',
         children: <path d="M0,0 L0,30 L10,15 z" fill="rgb(123, 234, 123)" />,
       };
@@ -130,7 +158,7 @@ describe('ArcherContainer', () => {
         markerHeight: 44,
         refX: 24,
         refY: 22,
-        orient: 'auto',
+        orient: 'auto-start-reverse',
         markerUnits: 'strokeWidth',
         children: <circle cx={22} cy={22} r={11} fill="#c0ffee" stroke="tomato" strokeWidth={2} />,
       };
@@ -152,21 +180,21 @@ describe('ArcherContainer', () => {
           const tree = renderer.create(arrow).toJSON();
 
           expect(tree).toMatchInlineSnapshot(`
-  <g>
-    <path
-      d="M0,0 C0,10 0,10 0,20"
-      markerEnd="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
-      style={
-        Object {
-          "fill": "none",
-          "stroke": "rgb(123, 234, 123)",
-          "strokeDasharray": "5,5",
-          "strokeWidth": 2,
-        }
-      }
-    />
-  </g>
-  `);
+            <g>
+              <path
+                d="M0,0 C0,10 0,10 0,20"
+                markerEnd="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
+                style={
+                  Object {
+                    "fill": "none",
+                    "stroke": "rgb(123, 234, 123)",
+                    "strokeDasharray": "5,5",
+                    "strokeWidth": 2,
+                  }
+                }
+              />
+            </g>
+          `);
         });
       });
 
@@ -183,21 +211,53 @@ describe('ArcherContainer', () => {
           const tree = renderer.create(arrow).toJSON();
 
           expect(tree).toMatchInlineSnapshot(`
-<g>
-  <path
-    d="M0,0 C0,11 0,11 0,22"
-    markerEnd="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
-    style={
-      Object {
-        "fill": "none",
-        "stroke": "rgb(123, 234, 123)",
-        "strokeDasharray": "5,5",
-        "strokeWidth": 2,
-      }
-    }
-  />
-</g>
-`);
+            <g>
+              <path
+                d="M0,0 C0,11 0,11 0,22"
+                markerEnd="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
+                style={
+                  Object {
+                    "fill": "none",
+                    "stroke": "rgb(123, 234, 123)",
+                    "strokeDasharray": "5,5",
+                    "strokeWidth": 2,
+                  }
+                }
+              />
+            </g>
+          `);
+        });
+      });
+
+      describe('with a marker at start', () => {
+        it('renders an SVG arrow on both ends', () => {
+          const wrapper: ShallowWrapper<typeof ArcherContainer> = shallowRenderAndSetState(
+            MarkerAtBothEndsState,
+          );
+          const uniquePrefix: string = wrapper.instance().arrowMarkerUniquePrefix;
+
+          const arrow = wrapper.instance()._computeArrows();
+
+          // $FlowFixMe TODO new error since flow upgrade
+          const tree = renderer.create(arrow).toJSON();
+
+          expect(tree).toMatchInlineSnapshot(`
+          <g>
+            <path
+              d="M0,-22 C0,0 0,0 0,22"
+              markerEnd="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
+              markerStart="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
+              style={
+                Object {
+                  "fill": "none",
+                  "stroke": "rgb(123, 234, 123)",
+                  "strokeDasharray": "5,5",
+                  "strokeWidth": 2,
+                }
+              }
+            />
+          </g>
+        `);
         });
       });
     });
@@ -212,23 +272,22 @@ describe('ArcherContainer', () => {
 
           // $FlowFixMe TODO new error since flow upgrade
           const tree = renderer.create(marker).toJSON();
-
           expect(tree).toMatchInlineSnapshot(`
-<marker
-  id="${uniquePrefix}first-elementsecond-element"
-  markerHeight={30}
-  markerUnits="strokeWidth"
-  markerWidth={10}
-  orient="auto"
-  refX={0}
-  refY={15}
->
-  <path
-    d="M0,0 L0,30 L10,15 z"
-    fill="rgb(123, 234, 123)"
-  />
-</marker>
-`);
+            <marker
+              id="${uniquePrefix}first-elementsecond-element"
+              markerHeight={30}
+              markerUnits="strokeWidth"
+              markerWidth={10}
+              orient="auto-start-reverse"
+              refX={0}
+              refY={15}
+            >
+              <path
+                d="M0,0 L0,30 L10,15 z"
+                fill="rgb(123, 234, 123)"
+              />
+            </marker>
+          `);
         });
       });
 
@@ -245,25 +304,25 @@ describe('ArcherContainer', () => {
           const tree = renderer.create(marker).toJSON();
 
           expect(tree).toMatchInlineSnapshot(`
-          <marker
-            id="${uniquePrefix}first-elementsecond-element"
-            markerHeight={44}
-            markerUnits="strokeWidth"
-            markerWidth={44}
-            orient="auto"
-            refX={24}
-            refY={22}
-          >
-            <circle
-              cx={22}
-              cy={22}
-              fill="#c0ffee"
-              r={11}
-              stroke="tomato"
-              strokeWidth={2}
-            />
-          </marker>
-        `);
+            <marker
+              id="${uniquePrefix}first-elementsecond-element"
+              markerHeight={44}
+              markerUnits="strokeWidth"
+              markerWidth={44}
+              orient="auto-start-reverse"
+              refX={24}
+              refY={22}
+            >
+              <circle
+                cx={22}
+                cy={22}
+                fill="#c0ffee"
+                r={11}
+                stroke="tomato"
+                strokeWidth={2}
+              />
+            </marker>
+          `);
         });
       });
     });

--- a/src/SvgArrow.js
+++ b/src/SvgArrow.js
@@ -19,8 +19,8 @@ type Props = {
   endShape: Object,
 };
 
-function computeStartingArrowDirectionVector(startingAnchorOrientation) {
-  switch (startingAnchorOrientation) {
+function computeArrowDirectionVector(anchorOrientation) {
+  switch (anchorOrientation) {
     case 'left':
       return { arrowX: -1, arrowY: 0 };
     case 'right':
@@ -34,53 +34,19 @@ function computeStartingArrowDirectionVector(startingAnchorOrientation) {
   }
 }
 
-function computeEndingArrowDirectionVector(endingAnchorOrientation) {
-  switch (endingAnchorOrientation) {
-    case 'left':
-      return { arrowX: -1, arrowY: 0 };
-    case 'right':
-      return { arrowX: 1, arrowY: 0 };
-    case 'top':
-      return { arrowX: 0, arrowY: -1 };
-    case 'bottom':
-      return { arrowX: 0, arrowY: 1 };
-    default:
-      return { arrowX: 0, arrowY: 0 };
-  }
-}
-
-export function computeStartingPointAccordingToArrowHead(
-  xArrowHeadStart: number,
-  yArrowHeadStart: number,
-  arrowLength: number,
-  strokeWidth: number,
-  startingAnchorOrientation: AnchorPositionType,
-) {
-  const startingVector = computeStartingArrowDirectionVector(startingAnchorOrientation);
-
-  const { arrowX, arrowY } = startingVector;
-
-  const xStart = xArrowHeadStart + (arrowX * arrowLength * strokeWidth) / 2;
-  const yStart = yArrowHeadStart + (arrowY * arrowLength * strokeWidth) / 2;
-
-  return { xStart, yStart };
-}
-
-export function computeEndingPointAccordingToArrowHead(
-  xArrowHeadEnd: number,
-  yArrowHeadEnd: number,
+export function computeArrowPointAccordingToArrowHead(
+  xArrowHeadPoint: number,
+  yArrowHeadPoint: number,
   arrowLength: number,
   strokeWidth: number,
   endingAnchorOrientation: AnchorPositionType,
 ) {
-  const endingVector = computeEndingArrowDirectionVector(endingAnchorOrientation);
+  const { arrowX, arrowY } = computeArrowDirectionVector(endingAnchorOrientation);
 
-  const { arrowX, arrowY } = endingVector;
+  const xPoint = xArrowHeadPoint + (arrowX * arrowLength * strokeWidth) / 2;
+  const yPoint = yArrowHeadPoint + (arrowY * arrowLength * strokeWidth) / 2;
 
-  const xEnd = xArrowHeadEnd + (arrowX * arrowLength * strokeWidth) / 2;
-  const yEnd = yArrowHeadEnd + (arrowY * arrowLength * strokeWidth) / 2;
-
-  return { xEnd, yEnd };
+  return { xPoint, yPoint };
 }
 
 export function computeStartingAnchorPosition(
@@ -212,41 +178,41 @@ const SvgArrow = ({
     ? endShape.circle.radius * 2
     : endShape.arrow.arrowLength * 2;
 
-  const startingPointWithArrow = computeStartingPointAccordingToArrowHead(
+  // Starting point with arrow
+  const { xPoint: xStart, yPoint: yStart } = computeArrowPointAccordingToArrowHead(
     startingPoint.x,
     startingPoint.y,
     enableStartMarker ? actualArrowLength : 0,
     strokeWidth,
     startingAnchorOrientation,
   );
-  const { xStart, yStart } = startingPointWithArrow;
 
-  const endingPointWithArrow = computeEndingPointAccordingToArrowHead(
+  // Ending point with arrow
+  const { xPoint: xEnd, yPoint: yEnd } = computeArrowPointAccordingToArrowHead(
     endingPoint.x,
     endingPoint.y,
     actualArrowLength,
     strokeWidth,
     endingAnchorOrientation,
   );
-  const { xEnd, yEnd } = endingPointWithArrow;
 
-  const startingPosition = computeStartingAnchorPosition(
+  // Starting position
+  const { xAnchor1, yAnchor1 } = computeStartingAnchorPosition(
     xStart,
     yStart,
     xEnd,
     yEnd,
     startingAnchorOrientation,
   );
-  const { xAnchor1, yAnchor1 } = startingPosition;
 
-  const endingPosition = computeEndingAnchorPosition(
+  // Ending position
+  const { xAnchor2, yAnchor2 } = computeEndingAnchorPosition(
     xStart,
     yStart,
     xEnd,
     yEnd,
     endingAnchorOrientation,
   );
-  const { xAnchor2, yAnchor2 } = endingPosition;
 
   const pathString = computePathString({
     xStart,
@@ -268,15 +234,15 @@ const SvgArrow = ({
     yEnd,
   );
 
+  const markerUrl = `url(${location.href.split('#')[0]}#${arrowMarkerId})`;
+
   return (
     <g>
       <path
         d={pathString}
         style={{ fill: 'none', stroke: strokeColor, strokeWidth, strokeDasharray }}
-        markerStart={
-          enableStartMarker ? `url(${location.href.split('#')[0]}#${arrowMarkerId})` : undefined
-        }
-        markerEnd={`url(${location.href.split('#')[0]}#${arrowMarkerId})`}
+        markerStart={enableStartMarker ? markerUrl : undefined}
+        markerEnd={markerUrl}
       />
       {arrowLabel && (
         <foreignObject

--- a/src/SvgArrow.test.js
+++ b/src/SvgArrow.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { type ShallowWrapper, shallow } from 'enzyme';
 import SvgArrow, {
-  computeEndingPointAccordingToArrowHead,
+  computeArrowPointAccordingToArrowHead,
   computeStartingAnchorPosition,
   computeEndingAnchorPosition,
   computeLabelDimensions,
@@ -21,7 +21,7 @@ describe('SvgArrow', () => {
           strokeWidth: 2,
           endingAnchor: 'top',
         },
-        expected: { xEnd: 10, yEnd: 15 },
+        expected: { xPoint: 10, yPoint: 15 },
       },
       {
         message: 2,
@@ -32,7 +32,7 @@ describe('SvgArrow', () => {
           strokeWidth: 2,
           endingAnchor: 'top',
         },
-        expected: { xEnd: 10, yEnd: 18 },
+        expected: { xPoint: 10, yPoint: 18 },
       },
       {
         message: 3,
@@ -43,7 +43,7 @@ describe('SvgArrow', () => {
           strokeWidth: 1,
           endingAnchor: 'top',
         },
-        expected: { xEnd: 10, yEnd: 17.5 },
+        expected: { xPoint: 10, yPoint: 17.5 },
       },
       {
         message: 4,
@@ -54,14 +54,14 @@ describe('SvgArrow', () => {
           strokeWidth: 2,
           endingAnchor: 'bottom',
         },
-        expected: { xEnd: 10, yEnd: 25 },
+        expected: { xPoint: 10, yPoint: 25 },
       },
     ];
 
     dataSet.forEach(data => {
       it(`should compute coordinates of destination point excluding the arrow [data ${data.message}]`, () => {
         const { xEnd, yEnd, arrowLength, strokeWidth, endingAnchor } = data.input;
-        const result = computeEndingPointAccordingToArrowHead(
+        const result = computeArrowPointAccordingToArrowHead(
           xEnd,
           yEnd,
           arrowLength,

--- a/types/react-archer.d.ts
+++ b/types/react-archer.d.ts
@@ -69,6 +69,7 @@ export interface LineStyle {
   strokeColor?: string;
   strokeWidth?: number;
   strokeDasharray?: string;
+  startMarker?: boolean;
   noCurves?: boolean;
   endShape?: ShapeType;
 }

--- a/types/react-archer.d.ts
+++ b/types/react-archer.d.ts
@@ -1,3 +1,4 @@
+// @noflow
 import * as React from 'react';
 
 export interface ShapeType {
@@ -55,6 +56,11 @@ export interface ArcherContainerProps {
    * Customize the end shape of the line. Defaults to a traditional "arrow" (triangle) shape.
    */
   endShape?: ShapeType;
+
+  /**
+   * Set this to true of you want to render a marker at the start of the line
+   */
+  startMarker?: boolean;
 }
 
 export class ArcherContainer extends React.Component<ArcherContainerProps> {


### PR DESCRIPTION
I have an use-case where I need to sometimes have (arrow) markers on start of the line, instead of just on the end. I added this prop for toggling this behavior. Should be backwards-compatible as not setting the boolean just omits the start arrow.

Change for orient means:

> auto-start-reverse
If placed by marker-start, the marker is oriented 180° different from the orientation that would be used if auto where specified. For all other markers, auto-start-reverse means the same as auto.
[Source](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/orient) 