### PR TITLE
Add a new straight line option for drawing lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # react-archer
+
 [![CircleCI](https://circleci.com/gh/pierpo/react-archer.svg?style=svg)](https://circleci.com/gh/pierpo/react-archer)
 
 🏹 Draw arrows between DOM elements in React 🖋
@@ -14,11 +15,11 @@
 ![Example](https://raw.githubusercontent.com/pierpo/react-archer/master/example.png)
 
 ```jsx
-import { ArcherContainer, ArcherElement } from 'react-archer';
+import { ArcherContainer, ArcherElement } from 'react-archer';
 
 const rootStyle = { display: 'flex', justifyContent: 'center' };
-const rowStyle = { margin: '200px 0', display: 'flex', justifyContent: 'space-between', }
-const boxStyle = { padding: '10px', border: '1px solid black', };
+const rowStyle = { margin: '200px 0', display: 'flex', justifyContent: 'space-between' };
+const boxStyle = { padding: '10px', border: '1px solid black' };
 
 const App = () => {
   return (
@@ -77,7 +78,7 @@ const App = () => {
       </ArcherContainer>
     </div>
   );
-}
+};
 
 export default App;
 ```
@@ -88,12 +89,14 @@ export default App;
 
 #### Props
 
+<!-- prettier-ignore -->
 | Name | Type | Description |
 | - | - | - |
 | `strokeColor` | `string` | A color string `'#ff0000'`
 | `strokeWidth` | `number` | A size in `px`
 | `strokeDasharray` | `string` | Adds dashes to the stroke. It has to be a string representing an array of sizes. See some [SVG strokes documentation](https://www.w3schools.com/graphics/svg_stroking.asp).
 | `noCurves` | `boolean` | Set this to true if you want angles instead of curves
+| `lineStyle` | `string` | Can be one of `angle`, `curve` or `straight`. Setting this overrides `noCurves`.
 | `offset` | `number` | Optional number for space between element and start/end of stroke
 | `svgContainerStyle` | `Style` | Style of the SVG container element. Useful if you want to add a z-index to your SVG container to draw the arrows under your elements, for example.
 | `children` | `React.Node` |
@@ -104,9 +107,9 @@ export default App;
 If you access to the ref of your `ArcherContainer`, you will access the `refreshScreen` method.
 This will allow you to have more control on when you want to re-draw the arrows.
 
-
 ### `ArcherElement`
 
+<!-- prettier-ignore -->
 | Name | Type | Description |
 | - | - | - |
 | `id` | `string` | The id that will identify the Archer Element. Should only contain alphanumeric characters and standard characters that you can find in HTML ids.
@@ -136,13 +139,14 @@ The `ArcherStyle` type has the following shape:
   strokeWidth: number,
   strokeDasharray: number,
   noCurves: boolean,
+  lineStyle: string,
   endShape: Object
 }
 ```
 
 ## Troubleshooting
 
-#### My arrows don't re-render correctly...
+### My arrows don't re-render correctly...
 
 Try using the `refreshScreen` instance method on your `ArcherContainer` element. You can access it through the [ref of the component](https://reactjs.org/docs/refs-and-the-dom.html).
 

--- a/example/App.js
+++ b/example/App.js
@@ -6,6 +6,7 @@ import FourthExample from './FourthExample';
 import FifthExample from './FifthExample';
 import SixthExample from './SixthExample';
 import SeventhExample from './SeventhExample';
+import EighthExample from './EighthExample';
 
 const getExample = id => {
   switch (id) {
@@ -23,6 +24,8 @@ const getExample = id => {
       return SixthExample;
     case 7:
       return SeventhExample;
+    case 8:
+      return EighthExample;
     default:
       return SecondExample;
   }
@@ -48,6 +51,7 @@ const App = () => {
           <button onClick={() => setExampleId(5)}>Example 5</button>
           <button onClick={() => setExampleId(6)}>Example 6</button>
           <button onClick={() => setExampleId(7)}>Example 7</button>
+          <button onClick={() => setExampleId(8)}>Example 8</button>
         </div>
       )}
       <hr />

--- a/example/EighthExample.js
+++ b/example/EighthExample.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import ArcherContainer from '../src/ArcherContainer';
+import ArcherElement from '../src/ArcherElement';
+
+const rootStyle = { display: 'flex', justifyContent: 'center' };
+const rowStyle = {
+  margin: '200px 0',
+  display: 'flex',
+  justifyContent: 'space-between',
+};
+const boxStyle = { padding: '10px', border: '1px solid black' };
+
+const FirstExample = () => {
+  return (
+    <div style={{ height: '500px', margin: '50px' }}>
+      <ArcherContainer strokeColor="red" lineStyle="straight" offset={0} startMarker>
+        <div style={rootStyle}>
+          <ArcherElement
+            id="root"
+            relations={[
+              {
+                targetId: 'element2',
+                targetAnchor: 'top',
+                sourceAnchor: 'bottom',
+                style: { strokeDasharray: '5,5' },
+              },
+            ]}
+          >
+            <div style={boxStyle}>Root</div>
+          </ArcherElement>
+        </div>
+
+        <div style={rowStyle}>
+          <ArcherElement
+            id="element2"
+            relations={[
+              {
+                targetId: 'element3',
+                targetAnchor: 'left',
+                sourceAnchor: 'right',
+                style: { strokeColor: 'blue', strokeWidth: 1 },
+                label: <div style={{ marginTop: '-20px' }}>Arrow 2</div>,
+              },
+            ]}
+          >
+            <div style={boxStyle}>Element 2</div>
+          </ArcherElement>
+
+          <ArcherElement id="element3">
+            <div style={boxStyle}>Element 3</div>
+          </ArcherElement>
+
+          <ArcherElement
+            id="element4"
+            relations={[
+              {
+                targetId: 'root',
+                targetAnchor: 'right',
+                sourceAnchor: 'left',
+                label: 'Arrow 3',
+              },
+            ]}
+          >
+            <div style={boxStyle}>Element 4</div>
+          </ArcherElement>
+        </div>
+      </ArcherContainer>
+    </div>
+  );
+};
+
+export default FirstExample;

--- a/flow-typed/archer-types.js
+++ b/flow-typed/archer-types.js
@@ -40,6 +40,7 @@ declare type LineType = {
   strokeDasharray?: string,
   noCurves?: boolean,
   startMarker?: boolean,
+  lineStyle?: string,
 };
 
 type ValidShapeTypes = 'arrow' | 'circle';

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -22,6 +22,7 @@ type Props = {
   strokeWidth: number,
   strokeDasharray?: string,
   noCurves?: boolean,
+  lineStyle?: string,
   children: React$Node | FunctionChild,
   style?: Object,
   svgContainerStyle?: Object,
@@ -287,7 +288,9 @@ export class ArcherContainer extends React.Component<Props, State> {
 
         const strokeDasharray = style.strokeDasharray || this.props.strokeDasharray;
 
-        const noCurves = style.noCurves || this.props.noCurves;
+        const noCurves = !!(style.noCurves || this.props.noCurves);
+
+        const lineStyle = style.lineStyle || this.props.lineStyle || (noCurves ? 'angle' : 'curve');
 
         const offset = this.props.offset || 0;
 
@@ -317,7 +320,7 @@ export class ArcherContainer extends React.Component<Props, State> {
             strokeDasharray={strokeDasharray}
             arrowLabel={label}
             arrowMarkerId={this._getMarkerId(source, target)}
-            noCurves={!!noCurves}
+            lineStyle={lineStyle}
             offset={offset}
             enableStartMarker={!!startMarker}
             endShape={endShape}

--- a/src/SvgArrow.test.js
+++ b/src/SvgArrow.test.js
@@ -199,7 +199,7 @@ describe('SvgArrow', () => {
       strokeColor: 'blue',
       strokeWidth: 2,
       arrowMarkerId: 'arrow123123',
-      noCurves: false,
+      lineStyle: 'curve',
       endShape: {
         arrow: {
           arrowLength: 10,
@@ -228,12 +228,27 @@ describe('SvgArrow', () => {
     });
 
     it('should render path with no curves coordinates', () => {
-      wrapper.setProps({ noCurves: true });
+      wrapper.setProps({ lineStyle: 'angle' });
       wrapper.update();
       const path = wrapper.find('path');
 
       expect(path.props()).toMatchObject({
         d: 'M10,10 10,10 30,10 30,10',
+        markerEnd: 'url(http://localhost/#arrow123123)',
+        style: {
+          strokeWidth: 2,
+          stroke: 'blue',
+        },
+      });
+    });
+
+    it('should render path with straight line coordinates', () => {
+      wrapper.setProps({ lineStyle: 'straight' });
+      wrapper.update();
+      const path = wrapper.find('path');
+
+      expect(path.props()).toMatchObject({
+        d: 'M10,10 15.85786437626905,15.857864376269049',
         markerEnd: 'url(http://localhost/#arrow123123)',
         style: {
           strokeWidth: 2,

--- a/types/react-archer.d.ts
+++ b/types/react-archer.d.ts
@@ -14,6 +14,8 @@ export interface ShapeType {
   };
 }
 
+export type ValidLineStyles = 'angle' | 'straight' | 'curve';
+
 export interface ArcherContainerProps {
   /**
    * A color string
@@ -32,11 +34,6 @@ export interface ArcherContainerProps {
    * See https://www.w3schools.com/graphics/svg_stroking.asp
    */
   strokeDasharray?: string;
-
-  /**
-   * Set this to true if you want angles instead of curves
-   */
-  noCurves?: boolean;
 
   style?: React.CSSProperties;
 
@@ -61,6 +58,12 @@ export interface ArcherContainerProps {
    * Set this to true of you want to render a marker at the start of the line
    */
   startMarker?: boolean;
+
+  /**
+   * Define how the line is drawn, grid for angles, straight for direct line and curve for curves
+   */
+
+  lineStyle?: ValidLineStyles;
 }
 
 export class ArcherContainer extends React.Component<ArcherContainerProps> {
@@ -78,6 +81,7 @@ export interface LineStyle {
   startMarker?: boolean;
   noCurves?: boolean;
   endShape?: ShapeType;
+  lineStyle?: ValidLineStyles;
 }
 
 export type AnchorPosition = 'top' | 'bottom' | 'left' | 'right' | 'middle';


### PR DESCRIPTION
Controlled by a prop `lineStyle` while still being backwards-compatible with the `noCurves` prop.
Maybe in a some major release we can drop the `noCurves` prop in favor of the `lineStyle`.

example:
![image](https://user-images.githubusercontent.com/506596/114135847-83862600-9912-11eb-942f-5dfc7750d98d.png)
