### PR TITLE
Add support to disable the end marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,9 @@ The `ArcherStyle` type has the following shape:
   strokeDasharray: number,
   noCurves: boolean,
   lineStyle: string,
-  endShape: Object
-  startMarker: boolean;
-  endMarker: boolean;
+  endShape: Object,
+  startMarker: boolean,
+  endMarker: boolean,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ export default App;
 | `svgContainerStyle` | `Style` | Style of the SVG container element. Useful if you want to add a z-index to your SVG container to draw the arrows under your elements, for example.
 | `children` | `React.Node` |
 | `endShape` | `Object` | An object containing the props to configure the "end shape" of the arrow. Can be one of `arrow` (default) or `circle`. See [`ShapeType`](flow-typed/archer-types.js) for a complete list of available options.
+| `startMarker` | `boolean` | Optional flag (default `false`) to also add a marker at the start of the arrow.
+| `endMarker` | `boolean` | Optional flag (default `true`) to remove the marker at the end of the arrow.
 
 #### Instance methods
 
@@ -141,6 +143,8 @@ The `ArcherStyle` type has the following shape:
   noCurves: boolean,
   lineStyle: string,
   endShape: Object
+  startMarker: boolean;
+  endMarker: boolean;
 }
 ```
 

--- a/example/App.js
+++ b/example/App.js
@@ -7,6 +7,7 @@ import FifthExample from './FifthExample';
 import SixthExample from './SixthExample';
 import SeventhExample from './SeventhExample';
 import EighthExample from './EighthExample';
+import NinthExample from './NinthExample';
 
 const getExample = id => {
   switch (id) {
@@ -26,6 +27,8 @@ const getExample = id => {
       return SeventhExample;
     case 8:
       return EighthExample;
+    case 9:
+      return NinthExample;
     default:
       return SecondExample;
   }
@@ -44,14 +47,11 @@ const App = () => {
         <div>
           <h2>Example {exampleId}</h2>
           <p>Choose an example:</p>
-          <button onClick={() => setExampleId(1)}>Example 1</button>
-          <button onClick={() => setExampleId(2)}>Example 2</button>
-          <button onClick={() => setExampleId(3)}>Example 3</button>
-          <button onClick={() => setExampleId(4)}>Example 4</button>
-          <button onClick={() => setExampleId(5)}>Example 5</button>
-          <button onClick={() => setExampleId(6)}>Example 6</button>
-          <button onClick={() => setExampleId(7)}>Example 7</button>
-          <button onClick={() => setExampleId(8)}>Example 8</button>
+          {[...Array(9).keys()].map(value => (
+            <button key={value} onClick={() => setExampleId(value + 1)} style={{ marginRight: 8 }}>
+              `Example ${value + 1}`
+            </button>
+          ))}
         </div>
       )}
       <hr />

--- a/example/NinthExample.js
+++ b/example/NinthExample.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import ArcherContainer from '../src/ArcherContainer';
+import ArcherElement from '../src/ArcherElement';
+
+const rootStyle = { display: 'flex', justifyContent: 'center' };
+const rowStyle = {
+  margin: '200px 0',
+  display: 'flex',
+  justifyContent: 'space-between',
+};
+const boxStyle = { padding: '10px', border: '1px solid black' };
+
+const FirstExample = () => {
+  return (
+    <div style={{ height: '500px', margin: '50px' }}>
+      <ArcherContainer
+        strokeColor="red"
+        lineStyle="straight"
+        offset={0}
+        startMarker
+        endMarker={false}
+      >
+        <div style={rootStyle}>
+          <ArcherElement
+            id="root"
+            relations={[
+              {
+                targetId: 'element2',
+                targetAnchor: 'top',
+                sourceAnchor: 'bottom',
+                style: { strokeDasharray: '5,5' },
+              },
+            ]}
+          >
+            <div style={boxStyle}>Root</div>
+          </ArcherElement>
+        </div>
+
+        <div style={rowStyle}>
+          <ArcherElement
+            id="element2"
+            relations={[
+              {
+                targetId: 'element3',
+                targetAnchor: 'left',
+                sourceAnchor: 'right',
+                style: { strokeColor: 'blue', strokeWidth: 1 },
+                label: <div style={{ marginTop: '-20px' }}>Arrow 2</div>,
+              },
+            ]}
+          >
+            <div style={boxStyle}>Element 2</div>
+          </ArcherElement>
+
+          <ArcherElement id="element3">
+            <div style={boxStyle}>Element 3</div>
+          </ArcherElement>
+
+          <ArcherElement
+            id="element4"
+            relations={[
+              {
+                targetId: 'root',
+                targetAnchor: 'right',
+                sourceAnchor: 'left',
+                label: 'Arrow 3',
+              },
+            ]}
+          >
+            <div style={boxStyle}>Element 4</div>
+          </ArcherElement>
+        </div>
+      </ArcherContainer>
+    </div>
+  );
+};
+
+export default FirstExample;

--- a/flow-typed/archer-types.js
+++ b/flow-typed/archer-types.js
@@ -40,6 +40,7 @@ declare type LineType = {
   strokeDasharray?: string,
   noCurves?: boolean,
   startMarker?: boolean,
+  endMarker?: boolean,
   lineStyle?: string,
 };
 

--- a/src/ArcherContainer.js
+++ b/src/ArcherContainer.js
@@ -17,6 +17,7 @@ type FunctionChild = (context: React$Context<ArcherContainerContextType>) => Rea
 
 type Props = {
   startMarker?: boolean,
+  endMarker?: boolean,
   endShape?: ShapeType,
   strokeColor: string,
   strokeWidth: number,
@@ -280,6 +281,8 @@ export class ArcherContainer extends React.Component<Props, State> {
       ({ source, target, label, style = {} }: SourceToTargetType) => {
         const startMarker = style.startMarker || this.props.startMarker;
 
+        const endMarker = style.endMarker ?? this.props.endMarker ?? true;
+
         const endShape = this._createShapeObj(style);
 
         const strokeColor = style.strokeColor || this.props.strokeColor;
@@ -323,6 +326,7 @@ export class ArcherContainer extends React.Component<Props, State> {
             lineStyle={lineStyle}
             offset={offset}
             enableStartMarker={!!startMarker}
+            disableEndMarker={!endMarker}
             endShape={endShape}
           />
         );

--- a/src/ArcherContainer.test.js
+++ b/src/ArcherContainer.test.js
@@ -305,7 +305,7 @@ describe('ArcherContainer', () => {
           expect(tree).toMatchInlineSnapshot(`
           <g>
             <path
-              d="M0,-22 C0,0 0,0 0,22"
+              d="M0,-22 C0,-11 0,-11 0,0"
               markerStart="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
               style={
                 Object {

--- a/src/ArcherContainer.test.js
+++ b/src/ArcherContainer.test.js
@@ -95,6 +95,35 @@ describe('ArcherContainer', () => {
     },
   };
 
+  const MarkerOnlyAtStartState: WrapperState = {
+    sourceToTargetsMap: {
+      bar: [
+        {
+          source: {
+            anchor: 'top',
+            id: 'first-element',
+          },
+          target: {
+            anchor: 'bottom',
+            id: 'second-element',
+          },
+          style: {
+            startMarker: true,
+            endMarker: false,
+            endShape: {
+              circle: {
+                radius: 11,
+                strokeWidth: 2,
+                strokeColor: 'tomato',
+                fillColor: '#c0ffee',
+              },
+            },
+          },
+        },
+      ],
+    },
+  };
+
   const shallowRenderAndSetState = (newState?: WrapperState) => {
     const wrapper = shallow(
       <ArcherContainer {...defaultProps}>
@@ -246,6 +275,37 @@ describe('ArcherContainer', () => {
             <path
               d="M0,-22 C0,0 0,0 0,22"
               markerEnd="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
+              markerStart="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
+              style={
+                Object {
+                  "fill": "none",
+                  "stroke": "rgb(123, 234, 123)",
+                  "strokeDasharray": "5,5",
+                  "strokeWidth": 2,
+                }
+              }
+            />
+          </g>
+        `);
+        });
+      });
+
+      describe('with a marker only at start', () => {
+        it('renders an SVG arrow only on start', () => {
+          const wrapper: ShallowWrapper<typeof ArcherContainer> = shallowRenderAndSetState(
+            MarkerOnlyAtStartState,
+          );
+          const uniquePrefix: string = wrapper.instance().arrowMarkerUniquePrefix;
+
+          const arrow = wrapper.instance()._computeArrows();
+
+          // $FlowFixMe TODO new error since flow upgrade
+          const tree = renderer.create(arrow).toJSON();
+
+          expect(tree).toMatchInlineSnapshot(`
+          <g>
+            <path
+              d="M0,-22 C0,0 0,0 0,22"
               markerStart="url(http://localhost/#${uniquePrefix}first-elementsecond-element)"
               style={
                 Object {

--- a/src/SvgArrow.js
+++ b/src/SvgArrow.js
@@ -16,6 +16,7 @@ type Props = {
   lineStyle: string,
   offset?: number,
   enableStartMarker?: boolean,
+  disableEndMarker?: boolean,
   endShape: Object,
 };
 
@@ -190,6 +191,7 @@ const SvgArrow = ({
   lineStyle,
   offset,
   enableStartMarker,
+  disableEndMarker,
   endShape,
 }: Props) => {
   const actualArrowLength = endShape.circle
@@ -266,7 +268,7 @@ const SvgArrow = ({
         d={pathString}
         style={{ fill: 'none', stroke: strokeColor, strokeWidth, strokeDasharray }}
         markerStart={enableStartMarker ? markerUrl : undefined}
-        markerEnd={markerUrl}
+        markerEnd={disableEndMarker ? undefined : markerUrl}
       />
       {arrowLabel && (
         <foreignObject

--- a/src/SvgArrow.js
+++ b/src/SvgArrow.js
@@ -214,7 +214,7 @@ const SvgArrow = ({
   const { xPoint: xEnd, yPoint: yEnd } = computeArrowPointAccordingToArrowHead(
     endingPoint.x,
     endingPoint.y,
-    actualArrowLength,
+    disableEndMarker ? 0 : actualArrowLength,
     strokeWidth,
     endingAnchorOrientation,
     lineStyle,

--- a/types/react-archer.d.ts
+++ b/types/react-archer.d.ts
@@ -60,6 +60,11 @@ export interface ArcherContainerProps {
   startMarker?: boolean;
 
   /**
+   * Set this to false of you do not want to render a marker at the end of the line
+   */
+  endMarker?: boolean;
+
+  /**
    * Define how the line is drawn, grid for angles, straight for direct line and curve for curves
    */
 
@@ -79,6 +84,7 @@ export interface LineStyle {
   strokeWidth?: number;
   strokeDasharray?: string;
   startMarker?: boolean;
+  endMarker?: boolean;
   noCurves?: boolean;
   endShape?: ShapeType;
   lineStyle?: ValidLineStyles;


### PR DESCRIPTION
Since https://github.com/pierpo/react-archer/pull/134 it is now possible to add markers also to the start. To fully utilize this, see e.g. https://github.com/pierpo/react-archer/issues/77, it is important  to be able to hide the end marker. This is what this PR tries to achieve.