### PR TITLE
feature: ignore warnings when a target or source is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ export default App;
 | `endShape` | `Object` | An object containing the props to configure the "end shape" of the arrow. Can be one of `arrow` (default) or `circle`. See [`ShapeType`](flow-typed/archer-types.js) for a complete list of available options.
 | `startMarker` | `boolean` | Optional flag (default `false`) to also add a marker at the start of the arrow.
 | `endMarker` | `boolean` | Optional flag (default `true`) to remove the marker at the end of the arrow.
+| `ignoreNotFoundWarnings` | `boolean` | Set this to true if you want to ignore warnings when a target or source is not found
 
 #### Instance methods
 

--- a/src/ArcherContainer/ArcherContainer.tsx
+++ b/src/ArcherContainer/ArcherContainer.tsx
@@ -36,6 +36,7 @@ const ArcherContainer = React.forwardRef<ArcherContainerHandle, ArcherContainerP
       offset,
       startMarker,
       strokeDasharray,
+      ignoreNotFoundWarnings,
       style,
     }: ArcherContainerProps,
     archerContainerRef,
@@ -161,6 +162,7 @@ const ArcherContainer = React.forwardRef<ArcherContainerHandle, ArcherContainerP
               noCurves={noCurves}
               lineStyle={lineStyle}
               offset={offset}
+              ignoreNotFoundWarnings={ignoreNotFoundWarnings}
               parentCurrent={parent.current}
               refs={refs}
               uniqueId={uniqueId}

--- a/src/ArcherContainer/ArcherContainer.types.ts
+++ b/src/ArcherContainer/ArcherContainer.types.ts
@@ -62,6 +62,11 @@ export type ArcherContainerProps = {
    */
   noCurves?: boolean;
 
+  /**
+   * Set this to true if you want to ignore warnings when a target or source is not found
+   */
+  ignoreNotFoundWarnings?: boolean;
+
   children?: React.ReactNode | FunctionChild;
 };
 

--- a/src/ArcherContainer/__tests__/ArcherContainer.test.tsx
+++ b/src/ArcherContainer/__tests__/ArcherContainer.test.tsx
@@ -211,6 +211,35 @@ describe('ArcherContainer', () => {
         expect.stringMatching('Could not find target element'),
       );
     });
+
+    it('should render no arrow if id is not found and not raise a console.warn', () => {
+      console.warn = jest.fn();
+
+      const screen = render(
+        <ArcherContainer startMarker endMarker={false} ignoreNotFoundWarnings>
+          <ArcherElement
+            id="elem-left"
+            relations={[
+              {
+                sourceAnchor: 'left',
+                targetAnchor: 'right',
+                targetId: 'oh no',
+              },
+            ]}
+          >
+            <div>element 1</div>
+          </ArcherElement>
+          <ArcherElement id="oops">
+            <div>element 2</div>
+          </ArcherElement>
+        </ArcherContainer>,
+      );
+
+      expect(screen.baseElement).toMatchSnapshot();
+      expect(console.warn).not.toHaveBeenCalledWith(
+        expect.stringMatching('Could not find target element'),
+      );
+    });
   });
 
   describe('Event Listeners', () => {

--- a/src/ArcherContainer/__tests__/__snapshots__/ArcherContainer.test.tsx.snap
+++ b/src/ArcherContainer/__tests__/__snapshots__/ArcherContainer.test.tsx.snap
@@ -92,6 +92,47 @@ exports[`ArcherContainer rendering an svg with the marker element used to draw a
 </body>
 `;
 
+exports[`ArcherContainer rendering an svg with the marker element used to draw an svg arrow should render no arrow if id is not found and not raise a console.warn 1`] = `
+<body>
+  <div>
+    <div
+      style="position: relative;"
+    >
+      <svg
+        style="position: absolute; width: 100%; height: 100%; top: 0px; left: 0px; pointer-events: none;"
+      >
+        <defs>
+          <marker
+            id="arrow00001elem-leftoh_20no"
+            markerHeight="6"
+            markerUnits="strokeWidth"
+            markerWidth="10"
+            orient="auto-start-reverse"
+            refX="0"
+            refY="3"
+          >
+            <path
+              d="M0,0 L0,6 L10,3 z"
+              fill="#f00"
+            />
+          </marker>
+        </defs>
+      </svg>
+      <div
+        style="height: 100%;"
+      >
+        <div>
+          element 1
+        </div>
+        <div>
+          element 2
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;
+
 exports[`ArcherContainer rendering an svg with the marker element used to draw an svg arrow should render simple elements 1`] = `
 <body>
   <div>

--- a/src/ArcherContainer/components/SvgArrows.tsx
+++ b/src/ArcherContainer/components/SvgArrows.tsx
@@ -19,6 +19,7 @@ interface CommonProps {
   noCurves: ArcherContainerProps['noCurves'];
   lineStyle: ArcherContainerProps['lineStyle'];
   offset: ArcherContainerProps['offset'];
+  ignoreNotFoundWarnings: ArcherContainerProps['ignoreNotFoundWarnings'];
   uniqueId: string;
   refs: Record<string, HTMLElement>;
 }
@@ -60,12 +61,18 @@ const AdaptedArrow = (
   );
 
   if (!startingPoint) {
-    console.warn('[React Archer] Could not find starting point of element! Not drawing the arrow.');
+    if (!props.ignoreNotFoundWarnings) {
+      console.warn(
+        '[React Archer] Could not find starting point of element! Not drawing the arrow.',
+      );
+    }
     return null;
   }
 
   if (!endingPoint) {
-    console.warn('[React Archer] Could not find target element! Not drawing the arrow.');
+    if (!props.ignoreNotFoundWarnings) {
+      console.warn('[React Archer] Could not find target element! Not drawing the arrow.');
+    }
     return null;
   }
 
@@ -125,6 +132,7 @@ export const SvgArrows = (
           noCurves={props.noCurves}
           lineStyle={props.lineStyle}
           offset={props.offset}
+          ignoreNotFoundWarnings={props.ignoreNotFoundWarnings}
           parentCoordinates={parentCoordinates}
           refs={props.refs}
           uniqueId={props.uniqueId}


### PR DESCRIPTION
Pretty self-explanatory: 
ignore `console.warn` in case the target or source is not found.
