### PR TITLE
Add memoization to avoid rerenders when position is the same

### DIFF
--- a/src/ArcherContainer/components/SvgArrows.tsx
+++ b/src/ArcherContainer/components/SvgArrows.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Property } from 'csstype';
+import useUpdatableState from 'use-updatable-state';
 import Vector2 from '../../geometry/Vector2';
 import {
   getPointCoordinatesFromAnchorPosition,
@@ -26,12 +27,12 @@ interface CommonProps {
   cursor?: Property.Cursor;
 }
 
-const AdaptedArrow = (
+const AdaptedArrow = React.memo(function AdaptedArrow(
   props: Omit<SourceToTargetType, 'order'> &
     CommonProps & {
       parentCoordinates: Vector2;
     },
-) => {
+) {
   const style = props.style || {};
   const newStartMarker = style.startMarker || props.startMarker;
   const newEndMarker = style.endMarker ?? props.endMarker ?? true;
@@ -97,7 +98,7 @@ const AdaptedArrow = (
       cursor={cursor}
     />
   );
-};
+});
 
 export const SvgArrows = (
   props: {
@@ -105,7 +106,10 @@ export const SvgArrows = (
     sourceToTargetsMap: Record<string, SourceToTargetsArrayType>;
   } & CommonProps,
 ) => {
-  const parentCoordinates = getPointFromElement(props.parentCurrent);
+  const [parentCoordinates] = useUpdatableState(
+    getPointFromElement(props.parentCurrent),
+    (a, b) => a?.x === b?.x && a?.y === b?.y,
+  );
 
   if (!parentCoordinates) {
     // This happens when parent ref is not ready yet


### PR DESCRIPTION
`AdaptedArrow` component takes a while to render even though it's only noticeable when there are many connections visible. There's no need to render them again if the position is stale.
I made this simple solution for my project and it does the job. You may come up with the better one, but I'd highly appreciate this change to be included. Sorry, I wasn't able to run/compile your project correctly due to lack of time, so just posting this concept.
Thanks for your work.